### PR TITLE
Fix setting of PUB_CACHE env variable

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -118,4 +118,5 @@ runs:
           -n '${{ steps.flutter-action.outputs.VERSION }}' \
           -a '${{ steps.flutter-action.outputs.ARCHITECTURE }}' \
           -c '${{ steps.flutter-action.outputs.CACHE-PATH }}' \
+          -d '${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}' \
           ${{ steps.flutter-action.outputs.CHANNEL }}


### PR DESCRIPTION
Pass the PUB-CACHE-KEY to the setup script to properly set PUB_CACHE location.